### PR TITLE
  Add Indonesia (KEMENAG) prayer time calculation method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+### Xcode ###
+# User settings
+xcuserdata/
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+# Build products
+build/
+DerivedData/
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# Xcode logs
+*.xcactivitylog
+*.xcdebugger
+*.xccrashpoint
+
+### Swift / SwiftPM ###
+.swiftpm/
+.build/
+Package.resolved
+
+### CocoaPods ###
+Pods/
+# If using workspace
+*.xcworkspace
+
+### Carthage ###
+Carthage/Build/
+
+### Fastlane ###
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output/
+
+### General ###
+.DS_Store
+*.orig
+*.lock
+.idea/
+*.iml
+
+### SPM / Tools ###
+.xcodeproj/project.xcworkspace/xcuserdata/
+.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
+
+### Optional (remove if you need to track them) ###
+# Xcode project files (if using `.xcodeproj` without a workspace, you may want to KEEP these)
+# *.pbxuser
+# *.mode1v3
+# *.mode2v3

--- a/PrayerTimes/PreferencesView.swift
+++ b/PrayerTimes/PreferencesView.swift
@@ -195,6 +195,7 @@ struct CalculationMethodView: View {
             .isna,
             .egypt,
             .karachi,
+            .indonesia,
             .custom(calculationMethod.calculationConfiguration)
         ]
     }
@@ -305,6 +306,7 @@ extension CalculationMethod {
         case .isna: return "Islamic Society of North America (ISNA)"
         case .egypt: return "Egyptian General Authority of Survey"
         case .karachi: return "University of Islamic Sciences, Karachi"
+        case .indonesia: return "Ministry of Religion Indonesia (KEMENAG)"
         case .custom: return "Custom"
         }
     }

--- a/PrayerTimesKit/CalculationParameters.swift
+++ b/PrayerTimesKit/CalculationParameters.swift
@@ -92,7 +92,8 @@ public enum CalculationMethod: Hashable, Codable {
     case isna
     case egypt
     case karachi
-    
+    case indonesia
+
     case custom(CalculationParameters.Configuration)
     
     public var calculationConfiguration: CalculationParameters.Configuration {
@@ -105,6 +106,8 @@ public enum CalculationMethod: Hashable, Codable {
             return .init(asrFactor: 1, fajrAngle: 19.5, ishaAngle: 17.5)
         case .karachi:
             return .init(asrFactor: 1, fajrAngle: 18, ishaAngle: 18)
+        case .indonesia:
+            return .init(asrFactor: 1, fajrAngle: 20, ishaAngle: 18)
         case .custom(let calculationConfiguration):
             return calculationConfiguration
         }

--- a/PrayerTimesKitTests/DailyPrayersTests.swift
+++ b/PrayerTimesKitTests/DailyPrayersTests.swift
@@ -270,7 +270,90 @@ class DailyPrayersTests: XCTestCase {
         
         mayExpected.validateDay(dateComponents: dateComponents, calculationParameters: calculationParameters)
     }
-    
+
+    func testKemenagJakarta() {
+        // Test KEMENAG (Kementrian Agama Indonesia) calculation method
+        // Jakarta, Indonesia coordinates
+        let timeZone = TimeZone(identifier: "Asia/Jakarta")!
+        let calculationParameters = CalculationParameters(
+            timeZone: timeZone,
+            location: CLLocation(latitude: -6.200000, longitude: 106.816666),
+            configuration: CalculationMethod.indonesia.calculationConfiguration
+        )
+
+        var gregorianCalendar = Calendar(identifier: .gregorian)
+        gregorianCalendar.timeZone = timeZone
+
+        var dateComponents = DateComponents(calendar: gregorianCalendar, timeZone: timeZone)
+        dateComponents.year = 2024
+        dateComponents.month = 1
+        dateComponents.day = 15
+
+        let daily = DailyPrayers(day: dateComponents.date!, calculationParameters: calculationParameters)
+
+        // Verify KEMENAG configuration is correctly applied (Fajr: 20°, Isha: 18°)
+        let config = CalculationMethod.indonesia.calculationConfiguration
+        XCTAssertEqual(config.fajrAngle, 20)
+        XCTAssertEqual(config.ishaAngle, 18)
+        XCTAssertEqual(config.asrFactor, 1)
+
+        // Verify prayer times are in correct chronological order
+        XCTAssert(daily.isha.start.timeIntervalSince(daily.maghrib.start) > 0)
+        XCTAssert(daily.maghrib.start.timeIntervalSince(daily.asr.start) > 0)
+        XCTAssert(daily.asr.start.timeIntervalSince(daily.dhuhr.start) > 0)
+        XCTAssert(daily.dhuhr.start.timeIntervalSince(daily.sunrise.start) > 0)
+        XCTAssert(daily.sunrise.start.timeIntervalSince(daily.fajr.start) > 0)
+        XCTAssert(daily.fajr.start.timeIntervalSince(daily.qiyam.start) > 0)
+
+        // Verify prayer times are reasonable for Jakarta (equatorial location)
+        // Fajr should be between 4:00 and 5:30
+        let fajrComponents = gregorianCalendar.dateComponents([.hour, .minute], from: daily.fajr.start)
+        XCTAssert(fajrComponents.hour! >= 4 && fajrComponents.hour! <= 5, "Fajr hour should be between 4 and 5")
+
+        // Dhuhr should be around noon (11:00 - 13:00)
+        let dhuhrComponents = gregorianCalendar.dateComponents([.hour], from: daily.dhuhr.start)
+        XCTAssert(dhuhrComponents.hour! >= 11 && dhuhrComponents.hour! <= 13, "Dhuhr should be around noon")
+
+        // Isha should be in the evening (18:00 - 20:00)
+        let ishaComponents = gregorianCalendar.dateComponents([.hour], from: daily.isha.start)
+        XCTAssert(ishaComponents.hour! >= 18 && ishaComponents.hour! <= 20, "Isha should be in the evening")
+    }
+
+    func testKemenagSurabaya() {
+        // Test KEMENAG calculation for Surabaya, Indonesia
+        let timeZone = TimeZone(identifier: "Asia/Jakarta")!
+        let calculationParameters = CalculationParameters(
+            timeZone: timeZone,
+            location: CLLocation(latitude: -7.249222, longitude: 112.750833),
+            configuration: CalculationMethod.indonesia.calculationConfiguration
+        )
+
+        var gregorianCalendar = Calendar(identifier: .gregorian)
+        gregorianCalendar.timeZone = timeZone
+
+        var dateComponents = DateComponents(calendar: gregorianCalendar, timeZone: timeZone)
+        dateComponents.year = 2024
+        dateComponents.month = 6
+        dateComponents.day = 15
+
+        let daily = DailyPrayers(day: dateComponents.date!, calculationParameters: calculationParameters)
+
+        // Verify prayer times are in correct chronological order
+        XCTAssert(daily.isha.start.timeIntervalSince(daily.maghrib.start) > 0)
+        XCTAssert(daily.maghrib.start.timeIntervalSince(daily.asr.start) > 0)
+        XCTAssert(daily.asr.start.timeIntervalSince(daily.dhuhr.start) > 0)
+        XCTAssert(daily.dhuhr.start.timeIntervalSince(daily.sunrise.start) > 0)
+        XCTAssert(daily.sunrise.start.timeIntervalSince(daily.fajr.start) > 0)
+        XCTAssert(daily.fajr.start.timeIntervalSince(daily.qiyam.start) > 0)
+
+        // Verify reasonable times for Surabaya (slightly south of equator)
+        let fajrComponents = gregorianCalendar.dateComponents([.hour], from: daily.fajr.start)
+        XCTAssert(fajrComponents.hour! >= 3 && fajrComponents.hour! <= 5, "Fajr hour should be between 3 and 5")
+
+        let dhuhrComponents = gregorianCalendar.dateComponents([.hour], from: daily.dhuhr.start)
+        XCTAssert(dhuhrComponents.hour! >= 11 && dhuhrComponents.hour! <= 13, "Dhuhr should be around noon")
+    }
+
 }
 
 private extension Date {

--- a/PrayerTimesWKExtension/PreferencesView.swift
+++ b/PrayerTimesWKExtension/PreferencesView.swift
@@ -80,6 +80,7 @@ struct CalculationMethodView: View {
             .isna,
             .egypt,
             .karachi,
+            .indonesia,
             .custom(calculationMethod.calculationConfiguration)
         ]
     }
@@ -219,6 +220,7 @@ extension CalculationMethod {
         case .isna: return "Islamic Society of North America (ISNA)"
         case .egypt: return "Egyptian General Authority of Survey"
         case .karachi: return "University of Islamic Sciences, Karachi"
+        case .indonesia: return "Ministry of Religion Indonesia (KEMENAG)"
         case .custom: return "Custom"
         }
     }


### PR DESCRIPTION
 ## Summary

  - Add support for Indonesia's Ministry of Religion (KEMENAG) calculation method with Fajr angle 20° and Isha angle 18°
  - Include KEMENAG option in calculation method picker for both iOS and watchOS apps
  - Add comprehensive test coverage for Jakarta and Surabaya locations
  - Initialize `.gitignore` with standard Xcode/Swift project exclusions

  ## Changes

  ### PrayerTimesKit
  - Added `.indonesia` case to `CalculationMethod` enum
  - Configured KEMENAG parameters: `asrFactor: 1`, `fajrAngle: 20`, `ishaAngle: 18`

  ### UI
  - Added Indonesia option to calculation method picker in iOS and watchOS preference views
  - Display name: "Ministry of Religion Indonesia (KEMENAG)"